### PR TITLE
fix: DaRacci/slimjar#17 (JSON files not relocating)

### DIFF
--- a/gradle-plugin/src/main/kotlin/io/github/slimjar/Utils.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/slimjar/Utils.kt
@@ -6,10 +6,7 @@ import org.gradle.api.tasks.TaskContainer
 import org.gradle.kotlin.dsl.getByType
 
 internal val TaskContainer.targetedJarTask: Task get() {
-    return findByName("reobfJar")
-        ?: findByName("shadowJar")
-        ?: findByName("jar")
-        ?: error("No jar task found")
+    return findByName("jar") ?: error("No jar task found")
 }
 
 internal val Project.slimExtension: SlimJarExtension get() = extensions.getByType()


### PR DESCRIPTION
Fixes #17, where the slimjar-generated JSON files did not get shaded in the final jar, due to shadowJar finishing first and thus no longer taking any extra files.